### PR TITLE
Fix bug print, implement dummy diversity

### DIFF
--- a/libs/simsom/config/default_simulator_config.json
+++ b/libs/simsom/config/default_simulator_config.json
@@ -6,5 +6,5 @@
     "threshold_convergence": 0.01,
     "filter_illegal": true,
     "verbose": true,
-    "print_interval": 100
+    "print_interval": 1000
 }

--- a/libs/simsom/simsom.py
+++ b/libs/simsom/simsom.py
@@ -96,6 +96,8 @@ def main():
             size=size,
             rank_index=RANK_INDEX,
             filter_illegal=simulator_config["filter_illegal"],
+            verbose=simulator_config["verbose"],
+            print_interval=simulator_config["print_interval"],
             batch_size=simulator_config["data_manager_batchsize"],
             save_passive_interaction=simulator_config["save_passive_interaction"],
         )

--- a/libs/simsom/simtools.py
+++ b/libs/simsom/simtools.py
@@ -96,7 +96,10 @@ def init_network(file=None, net_size=200, p=0.5, k_out=3) -> dict:
 
 
 def init_files(
-    folder_path: str, file_path_activity: str, file_path_passivity: str
+    folder_path: str,
+    file_path_activity: str,
+    file_path_passivity: str,
+    file_path_diversity: str,
 ) -> None:
     """Generate empty files to persist actions
 
@@ -111,6 +114,9 @@ def init_files(
         os.remove(file_path_activity)
     if os.path.isfile(file_path_passivity):
         os.remove(file_path_passivity)
+    if os.path.isfile(file_path_diversity):
+        os.remove(file_path_diversity)
+
     with open(file_path_activity, "w", newline="", encoding="utf-8") as out_act:
         csv_out_act = csv.writer(out_act)
         if os.stat(file_path_activity).st_size == 0:
@@ -138,3 +144,6 @@ def init_files(
                     "message_user_id",
                 ]
             )
+
+    with open(file_path_diversity, "w", encoding="utf-8") as diversity_file:
+        diversity_file.write("0")


### PR DESCRIPTION
Hello everyone.
I'm trying to get back up to speed with work and have been trying to implement diversity and fix the problems I left related to the convergence function.

1. implemented a temporary solution for the convergence parameter by removing the hard coded values
2. imported an early version of diversity, importing the function identically from the old simulator, I had to fix some problems:
- diversity is handled by the data manager and is “passed” to the convergence monitor
- to avoid unnecessary send and recv I used a support file (diversity_log.txt) which is edited by the data manager and read by the convergnce monitor so that I have a decent viewable output

Please go ahead and do a critical review on the changes, obviously many of being are just temporary solutions to try to import all the features and then start working on them in detail