### PR TITLE
Account suspension implementation

### DIFF
--- a/libs/simsom/agent_pool_manager_process.py
+++ b/libs/simsom/agent_pool_manager_process.py
@@ -24,13 +24,13 @@ def run_agent_pool_manager(
     comm_world.Barrier()
 
     while True:
-
+        print(f"Agent pool manager @ rank {rank} waiting for batch...", flush=True)
         # Get data from policy filter
         user_packs_batch = comm_world.recv(
             source=rank_index["policy_filter"],
             status=status,
         )
-
+        print(f"Agent pool manager @ rank {rank} got the batch...", flush=True)
         # Check for termination
         if user_packs_batch == "sigterm":
             break

--- a/libs/simsom/agent_process.py
+++ b/libs/simsom/agent_process.py
@@ -22,24 +22,22 @@ def run_agent(
 
     while True:
         # Receive package that contains (friend ids, messages) from agent_pool_manager
-        # Wait for agent pack to process
-        print(f"Agent @ rank {rank} waiting for user pack...")
         user_pack = comm_world.recv(
             source=rank_index["agent_pool_manager"],
             status=status,
         )
-        print(f"Agent @ rank {rank} received user pack")
+        
         if user_pack == "sigterm":
             break
 
-        # Ensure backward compatibility with older user_packs
+        # Ensure backward compatibility with older user_packs as current_time is included for suspension 
         if len(user_pack) == 2:
             user, in_messages = user_pack
             current_time = None  # Default value if not included
         else:
             user, in_messages, current_time = user_pack
 
-        if not user.is_terminated and not user.is_suspended:
+        if not user.is_terminated and not user.is_suspended: #only go through the process when a user is both not suspended and not terminated
             # Keep track of the weight of the messages (if a message should appear more than one, it has more weight)
             weight_dict = {}
 
@@ -77,7 +75,6 @@ def run_agent(
         else:
             # For terminated or suspended users, send minimal data
             new_msgs, passive_actions = [], []
-            print(f"User {user.uid} no actions since it is suspended or terminated")
             
         # Repack the agent (updated feed) and actions (messages he produced)
         agent_pack_reply = (user, new_msgs, passive_actions)

--- a/libs/simsom/config/default_network_config.json
+++ b/libs/simsom/config/default_network_config.json
@@ -1,5 +1,5 @@
 {
-    "real_world_netowork": "./data/default_graph.gml",
+    "real_world_netowork": "./libs/simsom/data/default_graph.gml",
     "net_size": 200,
     "probability_follow": 0.5,
     "avg_n_friend": 3

--- a/libs/simsom/data_manager_process.py
+++ b/libs/simsom/data_manager_process.py
@@ -118,6 +118,8 @@ def run_data_manager(
     # Bootstrap sync
     comm_world.Barrier()
 
+    print(f"Data manager start @ rank: {rank}")
+
     # Batch processing
     message_count = 0
     while True:
@@ -158,7 +160,7 @@ def run_data_manager(
                 user_index = rnd.choice(range(n_users - i))
                 picked_user = users.pop(user_index)
                 # Get the incoming messages and pack
-                user_pack = (picked_user, incoming_messages[picked_user.uid])
+                user_pack = (picked_user, incoming_messages[picked_user.uid], clock.current_time)
                 # Add it to the batch
                 users_packs_batch.append(user_pack)
                 # Flush incoming messages

--- a/libs/simsom/policy_filter_process.py
+++ b/libs/simsom/policy_filter_process.py
@@ -1,6 +1,70 @@
 from mpi4py import MPI
 import time
 
+def suspension(user, users_packs_batch, current_time):
+    """
+    Handles user suspension and removes their messages from others' newsfeeds.
+
+    Args:
+        user (User): The user being processed.
+        user_packs_batch (list): List of (user, in_messages, current_time) tuples.
+        current_time (float): The current simulation time.
+    """
+    # Skip terminated users immediately
+    if user.is_terminated:
+        return
+    
+    # Check if suspension time has passed
+    if user.is_suspended and abs(current_time - user.suspended_time) > 1:
+        user.is_suspended = False  # Lift suspension
+
+    # Check if flagging time has passed
+    if user.is_flagged and abs(current_time - user.current_flagged_time) > 6:
+        if not user.is_second_flagged:
+            user.is_flagged = False
+            user.is_first_flagged = False
+            user.current_flagged_time = 0
+            user.first_flagged_time = 0
+        if user.is_second_flagged: #make a second flag as a first flag
+            user.is_first_flagged = True
+            user.first_flagged_time = user.second_flagged_time
+            user.current_flagged_time = user.second_flagged_time
+            user.is_second_flagged = False
+            user.second_flagged_time = 0
+
+    # If the user posted a bad message
+    if user.bad_message_posting:
+        if not user.is_flagged:
+            # First offense or flag reset: Flag and suspend
+            user.is_flagged = True
+            user.is_first_flagged = True
+            user.is_suspended = True
+            user.sus_strike_count += 1
+            user.first_flagged_time = current_time
+            user.current_flagged_time = current_time
+            user.suspended_time = current_time
+        else:
+            # Already flagged → Just suspend, increase strike count
+            user.is_suspended = True
+            user.is_second_flagged = True
+            user.second_flagged_time = current_time
+            user.suspended_time = current_time
+            user.sus_strike_count += 1
+
+        # **Clear the suspended user's feed**
+        if hasattr(user, "newsfeed"):
+            user.newsfeed = []
+
+        # **Remove suspended user’s messages from other users' newsfeeds**
+        for other_user, _, _ in users_packs_batch:
+            if hasattr(other_user, "newsfeed"):
+                other_user.newsfeed = [
+                    msg for msg in other_user.newsfeed if msg.uid != user.uid
+                ]
+
+    # Check for account termination
+    if user.sus_strike_count >= 3:
+        user.is_terminated = True
 
 def run_policy_filter(
     comm_world: MPI.Intercomm,
@@ -18,16 +82,29 @@ def run_policy_filter(
     while True:
 
         # Wait for a batch of (agents, in_messages) to process
+        print(f"Policy filter @ rank {rank} waiting for batch from data manager", flush=True)
         user_packs_batch = comm_world.recv(
             source=rank_index["data_manager"], status=status
         )
+        print(f"Policy filter @ rank {rank} received batch", flush=True)
 
         # Check for termination signal
         if user_packs_batch == "sigterm":
             comm_world.send("sigterm", dest=rank_index["agent_pool_manager"])
             break
+        # Process each user pack
+
+        for i, user_pack in enumerate(user_packs_batch):
+            user, in_messages, current_time = user_pack
+
+            # Apply suspension logic using the batch itself
+            suspension(user, user_packs_batch, current_time)
+            
+            # Update the user pack
+            user_packs_batch[i] = (user, in_messages, current_time)
 
         processed_batch = user_packs_batch
 
         # Redirect the processed batch to agent pool manager
+        #print(f"Sending batch from policy filter @ rank {rank}", flush=True)
         comm_world.send(processed_batch, dest=rank_index["agent_pool_manager"])

--- a/libs/simsom/policy_filter_process.py
+++ b/libs/simsom/policy_filter_process.py
@@ -99,7 +99,7 @@ def run_policy_filter(
 
             # Apply suspension logic using the batch itself
             suspension(user, user_packs_batch, current_time)
-            
+            print(f"User {user.uid} went through susension: suspension - {user.is_suspended}, termination - {user.is_terminated}", flush=True)
             # Update the user pack
             user_packs_batch[i] = (user, in_messages, current_time)
 

--- a/libs/simsom/simsom.py
+++ b/libs/simsom/simsom.py
@@ -46,13 +46,13 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
     "--network_spec",
     type=str,
-    default="./config/default_network_config.json",
+    default="./libs/simsom/config/default_network_config.json",
     help="File that contains configuration for the network",
 )
 parser.add_argument(
     "--simulator_spec",
     type=str,
-    default="./config/default_simulator_config.json",
+    default="./libs/simsom/config/default_simulator_config.json",
     help="File that contains configuration for the simulation",
 )
 

--- a/libs/simsom/user.py
+++ b/libs/simsom/user.py
@@ -36,17 +36,17 @@ class User:
         for _ in range(random.randrange(1, 6)):
             user_description.append(random.randrange(0, 5))
         self.user_description = list(set(user_description))
-        self.bad_message_posting = False
-        self.is_flagged = False
-        self.is_first_flagged = False
-        self.is_second_flagged = False
-        self.first_flagged_time = 0
-        self.second_flagged_time = 0
-        self.current_flagged_time = 0
-        self.is_suspended = False
-        self.suspended_time = 0
-        self.sus_strike_count = 0
-        self.is_terminated = False
+        self.bad_message_posting = False #Trait to track bad activities of users
+        self.is_flagged = False #Aggregate indicator for flagging
+        self.is_first_flagged = False #Indicator for first flagging
+        self.is_second_flagged = False #Indicator for second flagging
+        self.first_flagged_time = 0 #timestamp for first flagging
+        self.second_flagged_time = 0 #timestamp for second flagging
+        self.current_flagged_time = 0 #timestamp for flagging that is used for the current suspension/termination process
+        self.is_suspended = False #Indicator for suspension
+        self.suspended_time = 0 #timestamp for suspension
+        self.sus_strike_count = 0 #strike count for suspension
+        self.is_terminated = False #indicator for termination
         self.is_shadow = False
         self.mu = 0.5
 
@@ -140,7 +140,7 @@ class User:
         )
         # self.shared_messages.append(message_created)
 
-        # Check if the message quality is 0 and increment suspension strike count --> having 0.3 for testing
+        # Check if the message quality is below 0.01 and update bad_message_posting
         if message_created.quality < 0.01:
             self.bad_message_posting = True
             

--- a/libs/simsom/user.py
+++ b/libs/simsom/user.py
@@ -36,7 +36,17 @@ class User:
         for _ in range(random.randrange(1, 6)):
             user_description.append(random.randrange(0, 5))
         self.user_description = list(set(user_description))
+        self.bad_message_posting = False
+        self.is_flagged = False
+        self.is_first_flagged = False
+        self.is_second_flagged = False
+        self.first_flagged_time = 0
+        self.second_flagged_time = 0
+        self.current_flagged_time = 0
         self.is_suspended = False
+        self.suspended_time = 0
+        self.sus_strike_count = 0
+        self.is_terminated = False
         self.is_shadow = False
         self.mu = 0.5
 
@@ -129,6 +139,11 @@ class User:
             quality_params=self.quality_params,
         )
         # self.shared_messages.append(message_created)
+
+        # Check if the message quality is 0 and increment suspension strike count --> having 0.3 for testing
+        if message_created.quality < 0.1:
+            self.bad_message_posting = True
+            
         self.post_counter += 1
         return message_created
 

--- a/libs/simsom/user.py
+++ b/libs/simsom/user.py
@@ -141,7 +141,7 @@ class User:
         # self.shared_messages.append(message_created)
 
         # Check if the message quality is 0 and increment suspension strike count --> having 0.3 for testing
-        if message_created.quality < 0.1:
+        if message_created.quality < 0.01:
             self.bad_message_posting = True
             
         self.post_counter += 1


### PR DESCRIPTION
Hi all,

I have edited various parts of the whole system to implement the account suspension process.

While `policy_filter_process.py` is the most heavily edited one, I also had to edit `agent_process.py` and `user.py`.

What is happening in the version I created is:

1) On `user.py`, a user's bad message posting behavior is getting tracked in `def post_message`.
2) According to this info, `def suspension` deals with flagging, suspension, and termination process as I have presented in the group meeting (for details, see [here](https://docs.google.com/presentation/d/1AAfmAnFsc6CMIzCRLb32HUwibgeyi1829L1m4nMcPDI/edit#slide=id.g33c4d78c120_0_21))
3) Based on the `is_suspended` and/or `is_terminated` tag of user object, `agent_process.py` skip those users by the added condition `if not user.is_terminated and not user.is_suspended:` for whole message generation/propagation and user action process.

The current version of implementation might not be optimal as we can imagine just not passing suspended agents in the first place from `agent_pool_manager.py` (This was @btrantruong's suggestion).  But, for some reasons, that way of implementation makes the whole system breaks so I have implemented in the way I did. I assume this is something to be related to agent handlers  waiting for forever, but could not find the solution. As the current version runs well with expected changes of user behaviors, I see this is okay for now, but we cannot say for sure when the node size grows exponentially (which I assume what is needed for account suspension experiment).

It would be great if you all can see the changes before this week's meeting so we might be able to discuss this Friday on this.