### PR TITLE
Suspension base beta + analyzer_process.py edit

### DIFF
--- a/libs/simsom/agent_pool_manager_process.py
+++ b/libs/simsom/agent_pool_manager_process.py
@@ -58,13 +58,13 @@ def run_agent_pool_manager(
         # If is not termination signal, dispatch data to agent handlers
         dispatch_requests = []
 
-        for user in data:
+        for user, current_time in data:
             if user.is_suspended or user.is_terminated:
-                print("- Agent Pool Manager >> skipping suspended users", flush=True)
+                # print("- Agent Pool Manager >> skipping suspended users", flush=True)
                 continue  # Skip users who are suspended or terminated
         
             handler_rank = rnd.choice(agent_handlers_ranks)
-            req = comm_world.isend(user, dest=handler_rank)
+            req = comm_world.isend((user, current_time), dest=handler_rank)
             dispatch_requests.append(req)
 
         MPI.Request.waitall(dispatch_requests)

--- a/libs/simsom/agent_pool_manager_process.py
+++ b/libs/simsom/agent_pool_manager_process.py
@@ -16,14 +16,14 @@ def run_agent_pool_manager(
 ):
 
     # Verbose: use flush=True to print messages
-    # print("- Agent pool manager >> started", flush=True)
+    print("- Agent pool manager >> started", flush=True)
 
     # Status of the processes
     status = MPI.Status()
 
     # Ranks of all available agent handler
     agent_handlers_ranks = list(range(rank_index["agent_handler"], size))
-    # print("- Agent Pool Manager >> agent process ranks", agent_handlers_ranks, flush=True)
+    print("- Agent Pool Manager >> agent process ranks", agent_handlers_ranks, flush=True)
 
     # Bootstrap sync
     comm_world.Barrier()
@@ -45,7 +45,7 @@ def run_agent_pool_manager(
         # Check for termination
         if data == "sigterm":
             # Send termination signal to all agent handlers and print message
-            # print("- Agent Pool Manager >> termination signal", flush=True)
+            print("- Agent Pool Manager >> termination signal", flush=True)
             for i in range(rank_index["agent_handler"], size):
                 comm_world.send("sigterm", dest=i)
 
@@ -59,6 +59,10 @@ def run_agent_pool_manager(
         dispatch_requests = []
 
         for user in data:
+            if user.is_suspended or user.is_terminated:
+                print("- Agent Pool Manager >> skipping suspended users", flush=True)
+                continue  # Skip users who are suspended or terminated
+        
             handler_rank = rnd.choice(agent_handlers_ranks)
             req = comm_world.isend(user, dest=handler_rank)
             dispatch_requests.append(req)

--- a/libs/simsom/agent_process.py
+++ b/libs/simsom/agent_process.py
@@ -42,7 +42,7 @@ def run_agent(
                 _ = comm_world.recv(source=MPI.ANY_SOURCE, status=status)
             comm_world.Barrier()
             break
-        user = data
+        user, current_time = data
         
         new_msgs, passive_actions = user.make_actions()
         

--- a/libs/simsom/analyzer_process.py
+++ b/libs/simsom/analyzer_process.py
@@ -193,7 +193,7 @@ def run_analyzer(
         # Get data from policy filter
         data = comm_world.recv(source=rank_index["recommender_system"], status=status)
         # Unpack the data
-        user, activities, passivities = data
+        users_batch, activities, passivities = data
         # Count the number of messages
         n_data += len(activities)
         intermediate_n_user += 1
@@ -266,9 +266,13 @@ def run_analyzer(
                 current_quality_list = []
         # Use the convergence with exponential moving average
         elif ema_quality_method:
-            users.append(user)
-            feeds[user.uid] = user.newsfeed
-            if len(users) == n_users:
+            for user in users_batch: #edit as now we are getting users_batch (list) from recsys
+                feeds[user.uid] = user.newsfeed
+                users.append(user)
+
+            if len(users) >= n_users: #SY: changed since it never converges with suspension. Does this make sense?
+                if n_data == 0:
+                    continue  # Skip this round until at least 1 message has been recorded
                 users = []
                 quality_diff, new_quality = update_quality(current_quality=current_quality, overall_avg_quality=quality_sum / n_data)
                 current_quality = new_quality

--- a/libs/simsom/config/default_simulator_config.json
+++ b/libs/simsom/config/default_simulator_config.json
@@ -6,7 +6,7 @@
     "max_interactions_method": false,
     "max_iteration_target": 10000, 
     "ema_quality_method": true,
-    "ema_quality_convergence": 0.1,
+    "ema_quality_convergence": 0.005,
     "filter_illegal": true,
     "verbose": true,
     "print_interval": 100,

--- a/libs/simsom/data_manager_process.py
+++ b/libs/simsom/data_manager_process.py
@@ -106,8 +106,9 @@ def run_data_manager(
                 passive_actions_send = outgoing_passivities[picked_user.uid]
 
                 # Add it to the batch
-                users_packs_batch.append((picked_user, active_actions_send, passive_actions_send))
-                
+                current_time = clock.next_time() #get current_time as it is needed for policy
+                users_packs_batch.append((picked_user, active_actions_send, passive_actions_send, current_time)) #pack current_time with others
+
                 # TODO: Flush outgoing messages ????
                 outgoing_messages[picked_user.uid] = []
                 outgoing_passivities[picked_user.uid] = []
@@ -120,7 +121,12 @@ def run_data_manager(
             comm_world.send(users_packs_batch, dest=rank_index["recommender_system"])
 
         elif msg == "ping_policy":
-            continue
+            user, current_time = content
+            # Find and replace the user in the current users list
+            for i, existing_user in enumerate(users):
+                if existing_user.uid == user.uid:
+                    users[i] = user
+                    break
             # print("- Data manager >> ping policy")
 
         elif msg == "sigterm":
@@ -131,4 +137,4 @@ def run_data_manager(
                 _ = comm_world.recv(source=MPI.ANY_SOURCE, status=status)
             comm_world.Barrier()
             break
-    # print("- Data manager >> finished", flush=True)
+    print("- Data manager >> finished", flush=True)

--- a/libs/simsom/policy_filter_process.py
+++ b/libs/simsom/policy_filter_process.py
@@ -1,6 +1,60 @@
 from mpi4py import MPI
 import time
+from user import User
 
+def suspension_base(user, users_packs_batch, current_time):
+    """
+    Handles user suspension and removes their messages from newsfeeds of other users.
+
+    Args:
+        user (User): The user being processed.
+        users_packs_batch (list): List of (user, in_messages, current_time) tuples.
+        current_time (float): The current simulation time.
+    """
+    # Skip terminated users immediately
+    if user.is_terminated:
+        return
+
+    # Constants
+    STRIKE_WINDOW = 9     # Time window to evaluate strikes (e.g., 9 days for now)
+    SUSPENSION_DURATIONS = {1: 1, 2: 2}  # Suspension lengths per strike count (in days -- 1 and 2 for now)
+
+    # Remove expired strikes (outside the 90-day window)
+    user.strike_timestamps = [
+        ts for ts in user.strike_timestamps if current_time - ts <= STRIKE_WINDOW
+    ]
+
+    # Check if suspension should be lifted
+    if user.is_suspended and current_time >= user.suspension_lift_time:
+        user.is_suspended = False
+
+    # Handle bad message posting (new strike)
+    if user.bad_message_posting:
+        user.bad_message_posting = False
+        user.strike_timestamps.append(current_time)
+        user.sus_strike_count = len(user.strike_timestamps)
+
+        # Immediate termination if 3+ strikes within STRIKE_WINDOW
+        if user.sus_strike_count >= 3:
+            user.is_terminated = True
+            return
+
+        # Suspend user for appropriate duration
+        user.is_suspended = True
+        user.suspended_time = current_time
+        suspension_duration = SUSPENSION_DURATIONS.get(user.sus_strike_count, 14)
+        user.suspension_lift_time = current_time + suspension_duration
+
+        # Clear user's own newsfeed if it exists
+        if hasattr(user, "newsfeed"):
+            user.newsfeed = []
+
+        # Remove user's messages from others' newsfeeds
+        for other_user, _, _ in users_packs_batch:
+            if hasattr(other_user, "newsfeed"):
+                other_user.newsfeed = [
+                    msg for msg in other_user.newsfeed if msg.uid != user.uid
+                ]
 
 def run_policy_filter(
     comm_world: MPI.Intercomm,
@@ -10,7 +64,7 @@ def run_policy_filter(
 ):
 
     # Verbose: use flush=True to print messages
-    # print("- Policy process >> started", flush=True)
+    print("- Policy process >> started", flush=True)
 
     # Status of the processes
     status = MPI.Status()
@@ -32,7 +86,22 @@ def run_policy_filter(
                 _ = comm_world.recv(source=MPI.ANY_SOURCE, status=status)
             comm_world.Barrier()
             break
+        # Now we know `data` is safe to process (not a string)
+        user_packs_batch = data
 
+        # Defensive structure check #SY HERE
+        if isinstance(user_packs_batch, User):
+            raise TypeError("Expected a batch of (user, in_messages, current_time), got a single User object.")
+        elif not isinstance(user_packs_batch, list):
+            user_packs_batch = [user_packs_batch]
+
+        for i, user_pack in enumerate(user_packs_batch):
+            user, in_messages, current_time = user_pack
+            suspension_base(user, user_packs_batch, current_time)
+            user_packs_batch[i] = (user, in_messages, current_time)
+
+        comm_world.send(user_packs_batch, dest=rank_index["data_manager"])
+        
         count += 1
 
         if count == 10:

--- a/libs/simsom/user.py
+++ b/libs/simsom/user.py
@@ -145,8 +145,8 @@ class User:
         )
         # self.shared_messages.append(message_created)
 
-        # Check if the message quality is below 0.01 and update bad_message_posting
-        if message_created.quality < 0.01:
+        # Check if the message quality is 0 and update bad_message_posting
+        if message_created.quality == 0:
             self.bad_message_posting = True
             
         self.post_counter += 1

--- a/libs/simsom/user.py
+++ b/libs/simsom/user.py
@@ -46,7 +46,12 @@ class User:
         self.repost_counter = 0
         self.view_counter = 0
         self.user_topics = generate_user_topics()
-        self.is_suspended = False
+        self.bad_message_posting = False #Trait to track bad activities of users
+        self.strike_timestamps = [] #object to track timestamps
+        self.sus_strike_count = 0 #to track the strike counts
+        self.suspension_lift_time = 0 #timeout for current suspension
+        self.is_suspended = False #Indicator for suspension
+        self.is_terminated = False #indicator for termination
         self.is_shadow = False
         self.mu = 0.5
 
@@ -139,6 +144,11 @@ class User:
             quality_params=self.quality_params,
         )
         # self.shared_messages.append(message_created)
+
+        # Check if the message quality is below 0.01 and update bad_message_posting
+        if message_created.quality < 0.01:
+            self.bad_message_posting = True
+            
         self.post_counter += 1
         return message_created
 


### PR DESCRIPTION
- `suspension_base` implementation.
1. Creation of `def suspension_base` in `policy_filter_process.py` & editing `user.py`
Here, I implemented the suspension process based on what YouTube does (see https://support.google.com/youtube/answer/2802032?hl=en for details or my past slides).

Agents get suspended for a while if they post a bad message based on `user.bad_message_posting`, which I added in `user.py` (`user.bad_message_posting == True`, currently bad message is set as one with` quality = 0`). If their time for suspension is up, they got unsuspended.

If they get three strikes within a flagged time (`STRIKE_WINDOW`), they got terminated.

2. Editing `def run_policy_filter` and `data_manager_process.py` accordingly
I edited this part to run `def suspension_base`. I wrote the code to send updated data with `"ping_policy"` message for `data_manager` and commented out `count += 1` part assuming it is for testing. Please correct me if this is for something else.

I also had to edit other parts of code since I need `current_time` for `def suspension_base`, which will be further explained below.

3. Editing `data_manager_process.py, recommender_system.py, agent_process.py, agent_pool_manager_process.py`
I had to edit most of the processes as I need `current_time` for `def suspension_base`. I passed `current_time` with `user` object. Please do check whether my edit might cause any unexpected problem (the code runs, but still). 

I also moved the part that clears out messages from suspended users from other users' feed to `recommender_system.py` (line181 - 192) as I can access all other users' feed in that process only (as far as I understand). 

`agent_pool_manager_process.py` skip suspended/terminated users when it passes users to `agent_process.py`. It worked well without stopping, thanks to SUPSI team's edit.

- Editing `recommender_system.py` and `analyzer_process.py` 

1. As I already communicated with Gianluca via Slack, 

`comm_world.send((user, activities, passivities), dest=rank_index["analyzer"])` has an error, so I edited it to 
`comm_world.send((users, activities, passivities), dest=rank_index["analyzer"])`.

This edit caused some problems in `analyzer_process.py` as it was written assuming that only single `user` object would be passed from `recommender_system.py`. So I edited in the way that it can process `users`, which is the list of `user` objects.

2. I also edited the part related to convergence in `analyzer_process.py` as the condition `if len(users) == n_users:` were never met with suspension process implemented. So I edited it to `if len(users) >= n_users:` and now it converges in the way it is supposed to. But not sure whether this is the right way to edit. Please do check this for me.